### PR TITLE
CSS Moduleを使えるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ Usage
 
 const pon = require('pon')
 const browser = require('pon-task-browser')
+const { cssModule } = browser.plugins
 
 async function tryExample () {
   let run = pon({
     'ui:bundle': browser('ui/entrypoints', 'public/js', {
-      pattern: '*.js'
+      pattern: '*.js',
+      plugins: [ cssModule('ui/stylesheets', 'public/css/bundle.css') ]
     })
   })
 
@@ -116,6 +118,15 @@ Define task
 | options | Object |  Optional settings |
 | options.debug | boolean |  Source map enabled or not |
 | options.watchDelay | number |  Delay after watch |
+| options.plugins | Array |  Browserify plugins |
+
+
+### ``
+
+
+
+| Param | type | Description |
+| ---- | --- | ----------- |
 
 
 

--- a/example/example-usage.js
+++ b/example/example-usage.js
@@ -2,11 +2,13 @@
 
 const pon = require('pon')
 const browser = require('pon-task-browser')
+const { cssModule } = browser.plugins
 
 async function tryExample () {
   let run = pon({
     'ui:bundle': browser('ui/entrypoints', 'public/js', {
-      pattern: '*.js'
+      pattern: '*.js',
+      plugins: [ cssModule('ui/stylesheets', 'public/css/bundle.css') ]
     })
   })
 

--- a/lib/.index.js.hbs
+++ b/lib/.index.js.hbs
@@ -7,11 +7,13 @@
 'use strict'
 
 const define = require('./define')
+const plugins = require('./plugins')
 
 let lib = define.bind(this)
 
 Object.assign(lib, define, {
-  define
+  define,
+  plugins
 })
 
 module.exports = lib

--- a/lib/define.js
+++ b/lib/define.js
@@ -9,6 +9,7 @@
  * @param {Object} [options={}] - Optional settings
  * @param {boolean} [options.debug=!isProduction()] - Source map enabled or not
  * @param {number} [options.watchDelay=100] - Delay after watch
+ * @param {Array} [options.plugins] - Browserify plugins
  * @returns {function} Defined task
  */
 'use strict'
@@ -27,7 +28,8 @@ function define (srcDir, destDir, options = {}) {
     pattern = '*.js',
     cacheFile = 'tmp/browser-cache.json',
     debug = !isProduction(),
-    watchDelay = 100
+    watchDelay = 100,
+    plugins = []
   } = options
 
   const compiler = (code, inputSourceMap = null, options = {}) => co(function * () {
@@ -44,8 +46,11 @@ function define (srcDir, destDir, options = {}) {
       packageCache: {},
       fullPaths: false
     })
+    for (let [ plugin, pluginsOption ] of plugins) {
+      b.plugin(plugin, pluginsOption)
+    }
     return yield new Promise((resolve, reject) =>
-        b.bundle((err, src) => err ? reject(err) : resolve([ src ])
+      b.bundle((err, src) => err ? reject(err) : resolve([ src ])
       )
     )
   })

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,19 @@
 /**
  * Pon task to bundle browser script
  * @module pon-task-browser
- * @version 1.0.2
+ * @version 1.0.3
  */
 
 'use strict'
 
 const define = require('./define')
+const plugins = require('./plugins')
 
 let lib = define.bind(this)
 
 Object.assign(lib, define, {
-  define
+  define,
+  plugins
 })
 
 module.exports = lib

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,0 +1,9 @@
+'use strict'
+
+/**
+ * Define plugin for css module
+ * @param {string} rootDir - Root directory of styles
+ * @param {string} output - Out put file path
+ * @returns {Array} - Plugin
+ */
+exports.cssModule = (rootDir, output) => [ require('css-modulesify'), { rootDir, output } ]

--- a/misc/mocks/css/hoge.css
+++ b/misc/mocks/css/hoge.css
@@ -1,0 +1,3 @@
+.head {
+    color: white;
+}

--- a/misc/mocks/mock-entrypoint.js
+++ b/misc/mocks/mock-entrypoint.js
@@ -1,5 +1,6 @@
 'use strict'
 
-const {foo} = require('./mock-dep')
+const { foo } = require('./mock-dep')
+const hoge = require('./css/hoge.css')
 
 console.log(foo())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pon-task-browser",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Pon task to bundle browser script",
   "main": "lib",
   "browser": "shim/browser",
@@ -42,6 +42,7 @@
     "ape-updating": "^4.1.0",
     "asleep": "^1.0.3",
     "coz": "^6.0.20",
+    "css-modulesify": "^0.27.2",
     "injectmock": "^2.0.0",
     "pon-context": "^1.1.2",
     "pon-doc": "^1.0.1",

--- a/test/define_test.js
+++ b/test/define_test.js
@@ -28,7 +28,10 @@ describe('define', function () {
       `${__dirname}/../misc/mocks`,
       `${__dirname}/../tmp/testing-compiled`,
       {
-        pattern: '*-entrypoint.js'
+        pattern: '*-entrypoint.js',
+        plugins: [
+          [ require('css-modulesify'), { rootDir: `${__dirname}/../misc/mocks/css`, output: './tmp/m-style.css' } ]
+        ]
       }
     )
     ok(task)

--- a/test/plugins_test.js
+++ b/test/plugins_test.js
@@ -1,0 +1,27 @@
+/**
+ * Test case for plugins.
+ * Runs with mocha.
+ */
+'use strict'
+
+const plugins = require('../lib/plugins.js')
+const assert = require('assert')
+const co = require('co')
+
+describe('plugins', function () {
+  this.timeout(3000)
+
+  before(() => co(function * () {
+
+  }))
+
+  after(() => co(function * () {
+
+  }))
+
+  it('Plugins', () => co(function * () {
+
+  }))
+})
+
+/* global describe, before, after, it */


### PR DESCRIPTION
```javascript

'use strict'

const pon = require('pon')
const browser = require('pon-task-browser')
const { cssModule } = browser.plugins

async function tryExample () {
  let run = pon({
    'ui:bundle': browser('ui/entrypoints', 'public/js', {
      pattern: '*.js',
      plugins: [ cssModule('ui/stylesheets', 'public/css/bundle.css') ]
    })
  })

  run('ui:bundle')
}

tryExample()


```