### PR TITLE
Add fullpaths option

### DIFF
--- a/lib/define.js
+++ b/lib/define.js
@@ -9,6 +9,7 @@
  * @param {boolean} [options.debug=!isProduction()] - Source map enabled or not
  * @param {number} [options.watchDelay=100] - Delay after watch
  * @param {string[]} [options.watchTargets=[]] - Additional watch target filenames
+ * @param {boolean} [options.fullPaths=true] - Use full paths
  * @param {Array} [options.plugins] - Browserify plugins
  * @returns {function} Defined task
  */
@@ -34,7 +35,8 @@ function define (src, dest, options = {}) {
     plugins = [],
     externals = [],
     requires = [],
-    skipWatching = false
+    skipWatching = false,
+    fullPaths = true
   } = options
 
   const srcDir = src && path.dirname(src)
@@ -56,7 +58,7 @@ function define (src, dest, options = {}) {
       debug,
       basedir: options.src && path.dirname(options.src),
       packageCache: {},
-      fullPaths: false
+      fullPaths
     })
     browserifyIncremental(b, { cacheFile })
 


### PR DESCRIPTION
ブラウザでsource mapファイルを解釈した時に元のファイル名が上手くとれていなかったので。fullpahtsオプションを追加した

https://github.com/substack/node-browserify#browserifyfiles--opts